### PR TITLE
View Results button in Analysis Wizard

### DIFF
--- a/src/components/panels/simulator/AnalysisWizard.jsx
+++ b/src/components/panels/simulator/AnalysisWizard.jsx
@@ -66,19 +66,21 @@ export default function AnalysisWizard() {
     const formValues = usePanelProperty(panelId, "formValues")
     const [formValidated, setFormValidated] = useState()
 
+    
     // determine if we can move to next step or not
     let showNextButton = false
     switch (activeStep) {
         case 0: showNextButton = !!componentId
-            break
+        break
         case 1: showNextButton =
-            (parameterSource == TabValues.ENVIRONMENT && !!environmentId) ||
-            (parameterSource == TabValues.PARAMETERS && formValidated) ||
-            parameterSource == TabValues.INPUT
-            break
+        (parameterSource == TabValues.ENVIRONMENT && !!environmentId) ||
+        (parameterSource == TabValues.PARAMETERS && formValidated) ||
+        parameterSource == TabValues.INPUT
+        break
     }
-
+    
     // submission & response tracking
+    const [viewResults, setViewResults] = useState("") // used to display 'View Results' button once analysis is done
     const [results, setResults] = usePanelProperty(panelId, 'results', false)
     const [orchestrationUris, setOrchestrationUris] = usePanelProperty(panelId, 'orchestrationUris', false)
 
@@ -102,6 +104,7 @@ export default function AnalysisWizard() {
         // success case
         if (pollResult.runtimeStatus == RuntimeStatus.COMPLETED) {
             setResults(pollResult.output)
+            setViewResults("View Results")
             console.debug(`${panelTitle}: Analysis complete.`)
             showNotification({
                 message: `${panelTitle} has finished running.`,
@@ -268,7 +271,14 @@ export default function AnalysisWizard() {
                                 onClick={handleAnalysisRun}
                             >
                                 Run Analysis
-                            </Button>}
+                            </Button>}  
+                        {viewResults && <Button
+                            gradient={{ from: "green", to: "green" }}
+                            variant="gradient"
+                            radius="xl"
+                        
+                        >   {viewResults}
+                        </Button>}                  
                     </>}
             </Group>
         </Container>

--- a/src/components/panels/simulator/AnalysisWizard.jsx
+++ b/src/components/panels/simulator/AnalysisWizard.jsx
@@ -28,7 +28,7 @@ export const TabValues = {
 }
 
 
-export default function AnalysisWizard() {
+export default function AnalysisWizard({handleViewResult, isResults}) {
 
     const panelId = useContext(PanelContext)
 
@@ -80,7 +80,6 @@ export default function AnalysisWizard() {
     }
     
     // submission & response tracking
-    const [viewResults, setViewResults] = useState("") // used to display 'View Results' button once analysis is done
     const [results, setResults] = usePanelProperty(panelId, 'results', false)
     const [orchestrationUris, setOrchestrationUris] = usePanelProperty(panelId, 'orchestrationUris', false)
 
@@ -104,7 +103,6 @@ export default function AnalysisWizard() {
         // success case
         if (pollResult.runtimeStatus == RuntimeStatus.COMPLETED) {
             setResults(pollResult.output)
-            setViewResults("View Results")
             console.debug(`${panelTitle}: Analysis complete.`)
             showNotification({
                 message: `${panelTitle} has finished running.`,
@@ -251,14 +249,14 @@ export default function AnalysisWizard() {
                         <Button
                             variant="default"
                             onClick={prevStep}
-                            sx={{ visibility: activeStep == 0 || activeStep == 3 ? 'hidden' : 'visible' }}
+                            sx={{ display: activeStep == 0 || activeStep == 3 ? 'none' : 'block' }}
                         >
                             Back
                         </Button>
                         {activeStep < 2 ?
                             <Button
                                 onClick={nextStep}
-                                sx={{ visibility: showNextButton ? 'visible' : 'hidden' }}
+                                sx={{ display: showNextButton ? 'block' : 'none' }}
                             >
                                 Next step
                             </Button> :
@@ -272,12 +270,12 @@ export default function AnalysisWizard() {
                             >
                                 Run Analysis
                             </Button>}  
-                        {viewResults && <Button
+                        {isResults && activeStep === 2 && <Button
                             gradient={{ from: "green", to: "green" }}
                             variant="gradient"
                             radius="xl"
-                        
-                        >   {viewResults}
+                            onClick={handleViewResult}
+                        >   View Results
                         </Button>}                  
                     </>}
             </Group>

--- a/src/components/panels/simulator/SimulatorPanel.jsx
+++ b/src/components/panels/simulator/SimulatorPanel.jsx
@@ -29,7 +29,7 @@ export default function SimulatorPanel({ id }) {
     
     const [activeTab, setActiveTab] = useState(TabValues.SETUP);
 
-    function viewResultsTab(){
+    const viewResultsTab = () => {
         setActiveTab(TabValues.RESULTS)
     }
 

--- a/src/components/panels/simulator/SimulatorPanel.jsx
+++ b/src/components/panels/simulator/SimulatorPanel.jsx
@@ -7,6 +7,7 @@ import { useSelector } from 'react-redux'
 import { panelsSelectors } from '../../../redux/hooks/panelsHooks'
 import { createSelector } from '@reduxjs/toolkit'
 import StatusBadge from './StatusBadge'
+import { useState } from 'react'
 
 
 export const PanelContext = createContext()
@@ -25,11 +26,17 @@ export default function SimulatorPanel({ id }) {
             results => results && Object.keys(results).length
         )
     )
+    
+    const [activeTab, setActiveTab] = useState(TabValues.SETUP);
+
+    function viewResultsTab(){
+        setActiveTab(TabValues.RESULTS)
+    }
 
     return (
         <PanelContext.Provider value={id}>
             <StatusBadge />
-            <Tabs defaultValue={TabValues.SETUP} styles={tabStyles}>
+            <Tabs value={activeTab} onTabChange={setActiveTab} styles={tabStyles}>
                 <Tabs.List>
                     <Tabs.Tab value={TabValues.SETUP}>Setup</Tabs.Tab>
                     {resultLength && <Tabs.Tab value={TabValues.RESULTS}>
@@ -39,7 +46,7 @@ export default function SimulatorPanel({ id }) {
                 </Tabs.List>
                 <Tabs.Panel value={TabValues.SETUP}>
                     <ScrollArea style={{ height: 'calc(100vh - 93px)' }}>
-                        <AnalysisWizard />
+                        <AnalysisWizard handleViewResult = {viewResultsTab} isResults = {resultLength} />
                         <Space h={20} />
                     </ScrollArea>
                 </Tabs.Panel>


### PR DESCRIPTION
Added a 'View Results' button once a simulation is done running. It will bring the user directly to the results tab.

Also changed the style properties for the 'back' and 'next' buttons to use 'display' instead of the 'visibility' property. This fixed alignment issues and made them more centered.