### PR TITLE
Menu Selectors

### DIFF
--- a/src/activities.js
+++ b/src/activities.js
@@ -3,15 +3,55 @@ import BugReportView from "./components/activities/explorer/BugReportView"
 import GitHubView from "./components/activities/explorer/GitHubView";
 import { FileIcon, RemoteControlIcon, BugReport } from "./icons"
 import { RiGithubFill } from "react-icons/ri";
-
-
+import { GiThorHammer} from "react-icons/gi";
+import { ObjectTypes } from "./objectTypes";
+import { FaGraduationCap } from "react-icons/fa";
+import { BsGraphUpArrow } from "react-icons/bs";
+import { BiSolidFlask } from "react-icons/bi";
 
 export const Activities = {
     LocalFileExplorer: {
         id: "synbio.activity.local-file-explorer",
         title: "Local Explorer",
         component: ExplorerActivityView,
-        icon: FileIcon
+        icon: FileIcon,
+        objectTypesToList: Object.values(ObjectTypes).map(object => object.id) // Local Explorer should list every object
+    },
+    Model: {
+        id: "synbio.activity.model",
+        title: "Model",
+        component: ExplorerActivityView,
+        icon: BsGraphUpArrow,
+        objectTypesToList: [
+
+        ]
+    },
+    Build: {
+        id: "synbio.activity.build",
+        title: "Build",
+        component: ExplorerActivityView,
+        icon: GiThorHammer,
+        objectTypesToList: [
+            ObjectTypes.Plasmids.id
+        ]
+    },
+    Test: {
+        id: "synbio.activity.test",
+        title: "Test",
+        component: ExplorerActivityView,
+        icon: BiSolidFlask,
+        objectTypesToList: [
+
+        ]
+    },
+    Learn: {
+        id: "synbio.activity.learn",
+        title: "Learn",
+        component: ExplorerActivityView,
+        icon: FaGraduationCap,
+        objectTypesToList: [
+            
+        ]
     },
     // RemoteFileExplorer: {
     //     id: "synbio.activity.remote-file-explorer",
@@ -38,3 +78,4 @@ export const Activities = {
 export function getActivity(id) {
     return Object.values(Activities).find(act => act.id == id)
 }
+

--- a/src/activities.js
+++ b/src/activities.js
@@ -8,18 +8,28 @@ import { ObjectTypes } from "./objectTypes";
 import { FaGraduationCap } from "react-icons/fa";
 import { BsGraphUpArrow } from "react-icons/bs";
 import { BiSolidFlask } from "react-icons/bi";
+import { HiOutlinePuzzlePiece } from "react-icons/hi2";
 
 export const Activities = {
     LocalFileExplorer: {
-        id: "synbio.activity.local-file-explorer",
-        title: "Local Explorer",
+        id: "synbio.activity.entire-workflow",
+        title: "Entire Workflow",
         component: ExplorerActivityView,
         icon: FileIcon,
         objectTypesToList: Object.values(ObjectTypes).map(object => object.id) // Local Explorer should list every object
     },
-    Model: {
-        id: "synbio.activity.model",
-        title: "Model",
+    PartsSelection: {
+        id: "synbio.activity.parts-selection",
+        title: "Parts Selection",
+        component: ExplorerActivityView,
+        icon: HiOutlinePuzzlePiece,
+        objectTypesToList: [
+
+        ] 
+    },
+    Design: {
+        id: "synbio.activity.design",
+        title: "Design",
         component: ExplorerActivityView,
         icon: BsGraphUpArrow,
         objectTypesToList: [

--- a/src/activities.js
+++ b/src/activities.js
@@ -33,7 +33,10 @@ export const Activities = {
         component: ExplorerActivityView,
         icon: BsGraphUpArrow,
         objectTypesToList: [
-
+            ObjectTypes.SBOL.id,
+            ObjectTypes.SBML.id,
+            ObjectTypes.OMEX.id,
+            ObjectTypes.Analysis.id
         ]
     },
     Build: {

--- a/src/components/activities/Activities.jsx
+++ b/src/components/activities/Activities.jsx
@@ -40,7 +40,7 @@ export default function Activities() {
                 <Text style={{display:"inline"}} size={'xs'} ml={10}>
                     <SaveIndicatorDisplay/>
                 </Text>
-                <activityDef.component {...activityState} />
+                <activityDef.component {...activityState} objectTypesToList = {activityDef.objectTypesToList} />
             </Tabs.Panel>
         )
     })

--- a/src/components/activities/explorer/ExplorerActivityView.jsx
+++ b/src/components/activities/explorer/ExplorerActivityView.jsx
@@ -5,7 +5,7 @@ import { useWorkingDirectory } from '../../../redux/hooks/workingDirectoryHooks'
 import { IoRefreshOutline } from "react-icons/io5"
 import { useLocalStorage } from '@mantine/hooks'
 
-export default function ExplorerActivityView({ }) {
+export default function ExplorerActivityView({objectTypesToList }) {
 
     // handle first time visiting
     const [firstTime, setFirstTime] = useLocalStorage({ key: 'first-time-visiting', defaultValue: true })
@@ -24,7 +24,7 @@ export default function ExplorerActivityView({ }) {
 
     return workingDirectory ?
         <>
-            <ExplorerList workDir = {workingDirectory} />
+            <ExplorerList workDir = {workingDirectory} objectTypesToList = {objectTypesToList} />
             <Center mt={20}>
                 <FolderSelect onSelect={handleDirectorySelection}>
                     Switch Folder

--- a/src/components/activities/explorer/ExplorerList.jsx
+++ b/src/components/activities/explorer/ExplorerList.jsx
@@ -6,7 +6,7 @@ import ExplorerListItem from './ExplorerListItem'
 import SaveIndicatorDisplay from '../../saveIndicatorDisplay'
 
 
-export default function ExplorerList({workDir}) {
+export default function ExplorerList({workDir, objectTypesToList}) {
 
     // grab file handles
     const files = useFiles()
@@ -48,26 +48,28 @@ export default function ExplorerList({workDir}) {
                     // create AccordionItems by object type
                     Object.values(ObjectTypes).map((objectType, i) => {
                         // grab files of current type
-                        const filesOfType = files.filter(file => file.objectType == objectType.id)
+                        if(objectTypesToList.includes(objectType.id)){
+                            const filesOfType = files.filter(file => file.objectType == objectType.id)
+                            return (    
+                                <Accordion.Item value={objectType.id} key={i}>
+                                    <Accordion.Control>
+                                        <Title order={6} sx={titleStyle} >{objectType.listTitle}</Title>
+                                    </Accordion.Control>
+                                    <Accordion.Panel>
+                                        {objectType.createable &&
+                                            <CreateNewButton
+                                                onCreate={handleCreateObject(objectType)}
+                                                suggestedName={`New ${objectType.title}`}
+                                            >
+                                                New {objectType.title}
+                                            </CreateNewButton>
+                                        }
+                                        {createListItems(filesOfType, objectType.icon)}
+                                    </Accordion.Panel>
+                                </Accordion.Item>
+                            )
+                        }
 
-                        return (    
-                            <Accordion.Item value={objectType.id} key={i}>
-                                <Accordion.Control>
-                                    <Title order={6} sx={titleStyle} >{objectType.listTitle}</Title>
-                                </Accordion.Control>
-                                <Accordion.Panel>
-                                    {objectType.createable &&
-                                        <CreateNewButton
-                                            onCreate={handleCreateObject(objectType)}
-                                            suggestedName={`New ${objectType.title}`}
-                                        >
-                                            New {objectType.title}
-                                        </CreateNewButton>
-                                    }
-                                    {createListItems(filesOfType, objectType.icon)}
-                                </Accordion.Panel>
-                            </Accordion.Item>
-                        )
                     })
                 }
             </Accordion>

--- a/src/objectTypes.js
+++ b/src/objectTypes.js
@@ -1,9 +1,7 @@
 import { BiWorld } from "react-icons/bi"
 import { IoAnalyticsSharp } from "react-icons/io5"
 import { TbComponents } from "react-icons/tb"
-import { GrTestDesktop } from "react-icons/gr";
-import { MdAlignVerticalTop } from "react-icons/md";
-import { VscOutput } from "react-icons/vsc";
+
 export const ObjectTypes = {
     SBOL: {
         id: "synbio.object-type.sbol",
@@ -14,7 +12,6 @@ export const ObjectTypes = {
         createable: true,
         extension: '.xml',
         badgeLabel: "SBOL",
-        directory: "main"
     },
     SBML: {
         id: "synbio.object-type.sbml",
@@ -23,7 +20,6 @@ export const ObjectTypes = {
         fileMatch: /<sbml/,
         createable: false,
         badgeLabel: "SBML",
-        directory: "main"
     },
     OMEX: {
         id: "synbio.object-type.omex-archive",
@@ -33,7 +29,6 @@ export const ObjectTypes = {
         icon: BiWorld,
         createable: false,
         badgeLabel: "OMEX",
-        directory: "main"
     },
     Analysis: {
         id: "synbio.object-type.analysis",
@@ -43,7 +38,6 @@ export const ObjectTypes = {
         icon: IoAnalyticsSharp,
         createable: true,
         extension: '.analysis',
-        directory: "main"
     },
     Plasmids:{
         id: "synbio.object-type.plasmid",
@@ -52,7 +46,6 @@ export const ObjectTypes = {
         createable: true,
         extension: '.xml',
         icon: TbComponents,
-        directory: 'Plasmid',
         fileNameMatch: /\.xml$/
     }
 }

--- a/src/objectTypes.js
+++ b/src/objectTypes.js
@@ -5,8 +5,8 @@ import { TbComponents } from "react-icons/tb"
 export const ObjectTypes = {
     SBOL: {
         id: "synbio.object-type.sbol",
-        title: "SBOL Component",
-        listTitle: "SBOL Components",
+        title: "Design",
+        listTitle: "Designs",
         fileMatch: /<sbol:/,
         icon: TbComponents,
         createable: true,
@@ -15,16 +15,16 @@ export const ObjectTypes = {
     },
     SBML: {
         id: "synbio.object-type.sbml",
-        title: "SBML File",
-        listTitle: "SBML Files",
+        title: "Model",
+        listTitle: "Models",
         fileMatch: /<sbml/,
         createable: false,
         badgeLabel: "SBML",
     },
     OMEX: {
         id: "synbio.object-type.omex-archive",
-        title: "OMEX Archive",
-        listTitle: "OMEX Archives",
+        title: "Archive",
+        listTitle: "Archives",
         fileNameMatch: /\.omex$/,
         icon: BiWorld,
         createable: false,


### PR DESCRIPTION
Added different tabs on the left side panel.

- Parts Selection
- Design
- Build
- Test
- Learn

Right now they are sparsely populated with content, however should be easy for others to add which activities to show. This is done via activities.js and adding to the "objectTypesToBeListed" list.

Closes #47 