### PR TITLE
changed the name of models tab to model

### DIFF
--- a/src/activities.js
+++ b/src/activities.js
@@ -40,7 +40,7 @@ export const Activities = {
     },
     Model: {
         id: "synbio.activity.models",
-        title: "Models",
+        title: "Model",
         component: ExplorerActivityView,
         icon: BsGraphUpArrow,
         objectTypesToList: [


### PR DESCRIPTION
 This pull request closes #153 and changed the tab labeled "Models" to say "Model" instead