### PR TITLE
Adds cache to docker

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,19 +1,20 @@
 FROM tiangolo/uwsgi-nginx-flask:python3.10
 
-COPY ./sbs_server /app
 WORKDIR /app
 
 RUN mkdir -p /app/data
 
 ENV STATIC_PATH=/app/app/static
-
 ENV LISTEN_PORT=5003
 EXPOSE 5003
 
 # Install requirements
 COPY requirements.txt /app/
 RUN /usr/local/bin/python -m pip install --upgrade pip
-RUN pip install -r requirements.txt 
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install -r requirements.txt
+
+COPY ./sbs_server /app
 
 # Create uploads directory
 RUN mkdir -p /app/uploads && \


### PR DESCRIPTION
Adds a cache for docker to speed up rebuild times

Note, docker will not build properly unless the changes in #289 are made locally. This is not a PR specific issue.