### PR TITLE
Wire SeqImprove panel for postMessage round-trip

### DIFF
--- a/frontend/src/components/panels/SeqImproveFrame.jsx
+++ b/frontend/src/components/panels/SeqImproveFrame.jsx
@@ -40,7 +40,7 @@ export default function SeqImproveFrame({ fileTypeObjectId }) {
                             return
                         }
 
-                        const safeName = data.displayID
+                        const safeName = data.displayID + '.xml'
                         const plasmidsSubdir = ObjectTypes.Plasmids.subdirectory
                         const plasmidsDir = await workDir.getDirectoryHandle(plasmidsSubdir, { create: true })
                         const fileHandle = await createFileInDirectory(

--- a/frontend/src/components/panels/SeqImproveFrame.jsx
+++ b/frontend/src/components/panels/SeqImproveFrame.jsx
@@ -1,35 +1,89 @@
+import { LoadingOverlay, Progress } from '@mantine/core'
+import { showNotification } from '@mantine/notifications'
+import { useState, useEffect, useRef, useContext } from 'react'
+import { PanelContext } from './SeqImprovePanel'
+import { usePanelProperty } from '../../redux/hooks/panelsHooks'
 
-import { PanelContext } from "./SeqImprovePanel"
-import { useContext } from "react"
-import { useRef } from "react"
+export default function SeqImproveFrame({ fileTypeObjectId }) {
+    const { url, panelId } = useContext(PanelContext)
+    const [sbolContent, setSBOLContent] = usePanelProperty(panelId, 'sbol', false)
 
-export default function SeqImproveFrame({}) {
-
-    const url = useContext(PanelContext)
-    // iframe reference
     const iframeRef = useRef()
 
-    // loading states
+    const [iframeLoaded, setIFrameLoaded] = useState(false)
+    const [sbolContentLoaded, setSbolContentLoaded] = useState(!sbolContent)
+    const loadProgress = 10 + (iframeLoaded + sbolContentLoaded) * 45
+
+    const targetOrigin = (() => {
+        try { return new URL(url).origin } catch { return '*' }
+    })()
+
+    const messageListener = ({ data, source }) => {
+        if (source !== iframeRef.current?.contentWindow) return
+        if (data === 'graphServiceLoadedSBOL') {
+            setSbolContentLoaded(true)
+            return
+        }
+        if (data?.sbol) {
+            console.debug('Received SBOL from SeqImprove:', data.sbol.substring(0, 100))
+            setSBOLContent(data.sbol)
+            return
+        }
+        if (data?.error) {
+            showNotification({
+                title: 'SeqImprove error',
+                message: data.error.message,
+                color: 'red',
+            })
+        }
+    }
+
+    useEffect(() => {
+        window.addEventListener('message', messageListener)
+        return () => window.removeEventListener('message', messageListener)
+    }, [])
+
+    const handleIFrameLoad = () => {
+        setIFrameLoaded(true)
+        setSbolContentLoaded(!sbolContent)
+
+        iframeRef.current.contentWindow.postMessage(
+            sbolContent
+                ? { sbol: sbolContent, panelType: fileTypeObjectId }
+                : { panelType: fileTypeObjectId },
+            targetOrigin,
+        )
+    }
+
     return (
-        <>
-                <div style={containerStyle}>
-                    <iframe
-                        src={url + '?ignoreHTTPErrors=true'}
-                        style={iframeStyle}
-                        width="100%"
-                        height="100%"
-                        loading="lazy"
-                        ref={iframeRef}
-                        title="SeqImprove"
-                    />
-                </div>
-        </>
+        <div style={containerStyle}>
+            <iframe
+                src={url + '?ignoreHTTPErrors=true'}
+                style={iframeStyle(sbolContentLoaded)}
+                width="100%"
+                height="100%"
+                frameBorder="0"
+                onLoad={handleIFrameLoad}
+                loading="lazy"
+                ref={iframeRef}
+                title="SeqImprove"
+            />
+            {loadProgress < 100 && <>
+                <Progress value={loadProgress} radius={0} size="md" styles={progressStyles} />
+                <LoadingOverlay visible={true} overlayOpacity={0} />
+            </>}
+        </div>
     )
 }
 
-const iframeStyle  = ({
-    overflow: "hidden",
-    visibility: "visible"
+const progressStyles = theme => ({
+    root: { position: 'absolute', top: 0, width: '100%' },
+    bar: { transition: 'width 0.3s' },
+})
+
+const iframeStyle = show => ({
+    overflow: 'hidden',
+    visibility: show ? 'visible' : 'hidden',
 })
 
 const containerStyle = {

--- a/frontend/src/components/panels/SeqImproveFrame.jsx
+++ b/frontend/src/components/panels/SeqImproveFrame.jsx
@@ -3,6 +3,9 @@ import { showNotification } from '@mantine/notifications'
 import { useState, useEffect, useRef, useContext } from 'react'
 import { PanelContext } from './SeqImprovePanel'
 import { usePanelProperty } from '../../redux/hooks/panelsHooks'
+import store from '../../redux/store'
+import { createFileInDirectory, writeToFileHandle } from '../../redux/hooks/workingDirectoryHooks'
+import { ObjectTypes } from '../../objectTypes'
 
 export default function SeqImproveFrame({ fileTypeObjectId }) {
     const { url, panelId } = useContext(PanelContext)
@@ -27,6 +30,34 @@ export default function SeqImproveFrame({ fileTypeObjectId }) {
         if (data?.sbol) {
             console.debug('Received SBOL from SeqImprove:', data.sbol.substring(0, 100))
             setSBOLContent(data.sbol)
+
+            if (data.source === 'seqimprove') {
+                ;(async () => {
+                    try {
+                        const workDir = store.getState().workingDirectory.directoryHandle
+                        if (!workDir) {
+                            showNotification({ title: 'Save failed', message: 'No working directory selected', color: 'red' })
+                            return
+                        }
+
+                        const safeName = data.displayID
+                        const plasmidsSubdir = ObjectTypes.Plasmids.subdirectory
+                        const plasmidsDir = await workDir.getDirectoryHandle(plasmidsSubdir, { create: true })
+                        const fileHandle = await createFileInDirectory(
+                            plasmidsDir,
+                            safeName,
+                            ObjectTypes.Plasmids.id,
+                            store.dispatch,
+                            plasmidsSubdir,
+                        )
+                        await writeToFileHandle(fileHandle, data.sbol)
+                        showNotification({ title: 'Saved to working directory', message: `${plasmidsSubdir}/${safeName}`, color: 'teal' })
+                    }
+                    catch (err) {
+                        showNotification({ title: 'Save failed', message: err?.message ?? String(err), color: 'red' })
+                    }
+                })()
+            }
             return
         }
         if (data?.error) {

--- a/frontend/src/components/panels/SeqImprovePanel.jsx
+++ b/frontend/src/components/panels/SeqImprovePanel.jsx
@@ -1,19 +1,21 @@
 import { createContext } from 'react'
 import { useSelector } from 'react-redux'
 import SeqImproveFrame from './SeqImproveFrame'
+import PanelSaver from './PanelSaver'
 import { panelsSlice } from '../../redux/store'
 
 const { selectors } = panelsSlice
 
 export const PanelContext = createContext()
 
-export default function SeqImprovePanel({ id }) {
+export default function SeqImprovePanel({ id, fileObjectTypeId }) {
     const panel = useSelector(state => selectors.selectById(state, id))
     const url = panel?.url
-    
+
     return (
-        <PanelContext.Provider value={url}>
-            <SeqImproveFrame/>
+        <PanelContext.Provider value={{ url, panelId: id }}>
+            <SeqImproveFrame fileTypeObjectId={fileObjectTypeId} />
+            <PanelSaver id={id} />
         </PanelContext.Provider>
     )
 }

--- a/frontend/src/panels.js
+++ b/frontend/src/panels.js
@@ -143,8 +143,15 @@ export const PanelTypes = {
         component: SeqImprovePanel,
         icon: SynBioHub,
 
-        deserialize: content => ({ sbol: content }),
-        serialize: panel => panel.sbol ?? '',
+        deserialize: content => ({
+            sbol: content
+        }),
+        serialize: panel => {
+            if (!panel.sbol || panel.sbol.trim() === "") {
+                return BLANK_SBOL
+            }
+            return panel.sbol;
+        }
     }
 }
 

--- a/frontend/src/panels.js
+++ b/frontend/src/panels.js
@@ -142,6 +142,9 @@ export const PanelTypes = {
         title: "SeqImprove",
         component: SeqImprovePanel,
         icon: SynBioHub,
+
+        deserialize: content => ({ sbol: content }),
+        serialize: panel => panel.sbol ?? '',
     }
 }
 


### PR DESCRIPTION
## Summary
- #261

The SeqImprove iframe currently has no postMessage integration, so SynBioSuite can't hand SBOL into it or receive edits back. This wires up the handshake the same way CanvasFrame already does for SBOLCanvas, plus serialize/deserialize on the SeqImprove panel type so anything the iframe posts back actually persists through the existing autosave pipeline.

PR on the SeqImprove side: MyersResearchGroup/SeqImprove#187.

### What's in here

`SeqImproveFrame.jsx` is rewritten to mirror CanvasFrame. On iframe load it posts `{ sbol, panelType }` (or just `{ panelType }` when there's no existing content) to the iframe origin. It listens for `{ sbol }` from the child to update Redux, `'graphServiceLoadedSBOL'` to clear the loading overlay, and `{ error: { message } }` to surface a Mantine notification. The targetOrigin is computed from the URL via `new URL(url).origin`, so a stray trailing slash in `VITE_SEQIMPROVE_URL` won't silently drop messages.

`SeqImprovePanel.jsx` now exposes `{ url, panelId }` through PanelContext instead of just `url`, so the frame can call `usePanelProperty(panelId, 'sbol', false)`. It also mounts `<PanelSaver id={id}/>` so the 4-second autosave debounce actually fires for SeqImprove panels.

`panels.js` adds the missing `serialize` and `deserialize` on the SeqImprove panel type. Without them, `commands.FileSave.execute` was writing an empty string to disk regardless of what the iframe sent.

### Still todo:

The postMessage round-trip works after this is merged, but autosave-to-disk has one gap left. `OpenSeqImproveButton` dispatches `openPanel` without a `fileHandle`, so when autosave fires, `commands.FileSave.execute` stops with "File doesn't exist" and doesn't take any action.

Just need to have the button create a fileHandle on click via `useCreateFile`, the same way sbolcanvas's "New Plasmid" already works. 