### PR TITLE
Fix uploadExperiment to keep Flapjack optional and avoid accidental FJ uploads

### DIFF
--- a/backend/sbs_server/app/views.py
+++ b/backend/sbs_server/app/views.py
@@ -59,9 +59,8 @@ def sbh_fj_upload(files):
     if sbh_url and not (sbh_url.startswith('http://') or sbh_url.startswith('https://')):
         params_from_request['sbh_url'] = 'https://' + sbh_url
 
-    required_params = ['sbh_url', 'sbh_token', 'sbh_user', 'sbh_pass', 
-                       'fj_url', 'fj_token', 'fj_user', 'fj_pass', 
-                       'collection_url', 'sbh_overwrite', 'fj_overwrite']
+    required_params = ['sbh_url', 'sbh_token', 'sbh_user', 'sbh_pass',
+                       'collection_url', 'sbh_overwrite']
 
     for param in required_params:
         if param not in params_from_request:
@@ -70,6 +69,22 @@ def sbh_fj_upload(files):
         params_from_request['sbh_user'] is None and
         params_from_request['sbh_pass'] is None):
         return 'No SBH credentials provided', 400
+
+    fj_url = params_from_request.get('fj_url')
+    fj_token = params_from_request.get('fj_token')
+    fj_user = params_from_request.get('fj_user')
+    fj_pass = params_from_request.get('fj_pass')
+    fj_overwrite = params_from_request.get('fj_overwrite', 1)
+
+    if not fj_url:
+        fj_url = None
+        fj_token = None
+        fj_user = None
+        fj_pass = None
+    elif not fj_token and not (fj_user and fj_pass):
+        return jsonify({
+            "error": "Flapjack URL was provided, but no Flapjack credentials were provided"
+        }), 400
 
     # Attachment files to upload to SBH
     if 'Attachments' in files and 'attachments' in params_from_request:
@@ -122,11 +137,11 @@ def sbh_fj_upload(files):
                                       sbh_user = params_from_request['sbh_user'],
                                       sbh_pass = params_from_request['sbh_pass'], 
                                       sbh_token = params_from_request['sbh_token'],
-                                      fj_url = params_from_request['fj_url'],
-                                      fj_overwrite = params_from_request['fj_overwrite'], 
-                                      fj_user = params_from_request['fj_user'], 
-                                      fj_pass = params_from_request['fj_pass'],
-                                      fj_token = params_from_request['fj_token'])
+                                      fj_url = fj_url,
+                                      fj_overwrite = fj_overwrite, 
+                                      fj_user = fj_user, 
+                                      fj_pass = fj_pass,
+                                      fj_token = fj_token)
     except AttributeError as e:
         os.remove(metadata_path)
         return jsonify({"error": str(e)}), 400
@@ -312,4 +327,3 @@ def inspect_request():
     return jsonify({
         "message": "Request received successfully", 
         "files": files}), 200
-

--- a/frontend/src/API.js
+++ b/frontend/src/API.js
@@ -56,7 +56,7 @@ export async function upload_resource(
         const paramsObj = {
             sbh_url: sbh_url,
             sbh_token: sbh_token,
-            fj_url: "charmmefj-api.synbiohub.org",
+            fj_url: null,
             sbh_user: null,
             sbh_pass: null,
             fj_token: null,


### PR DESCRIPTION
### Motivation
- Prevent SynBioHub-only Study uploads (with attachments) from accidentally triggering Flapjack when no Flapjack credentials are provided.  
- Ensure the backend only requires SynBioHub/core params for normal uploads and treat Flapjack as optional.  

### Description
- Updated backend `sbh_fj_upload` in `backend/sbs_server/app/views.py` to require only SBH/core fields: `sbh_url`, `sbh_token`, `sbh_user`, `sbh_pass`, `collection_url`, and `sbh_overwrite`.  
- Read Flapjack params with `.get(...)` and set `fj_overwrite` default to `1`, making `fj_url`, `fj_token`, `fj_user`, and `fj_pass` optional.  
- Added conditional validation so that if `fj_url` is provided it requires either `fj_token` or both `fj_user` and `fj_pass`, and returns a clear 400 JSON error when a Flapjack URL is supplied with no credentials.  
- Pass normalized optional Flapjack values (`None` when not used) into `xdc.upload_to_existing_collection(...)` so SBH-only uploads do not forward spurious FJ arguments.  
- Updated frontend `frontend/src/API.js` to stop sending a default Flapjack host by setting `fj_url: null` in the `upload_resource` params payload to avoid inadvertently triggering Flapjack behavior.  

### Testing
- Compiled the backend file with `python -m py_compile backend/sbs_server/app/views.py` which succeeded.  
- Verified the frontend file is readable with `node -e "require('fs').readFileSync('frontend/src/API.js','utf8')"` which succeeded.  
- Programmatically inspected the diffs to confirm only the intended files (`backend/sbs_server/app/views.py` and `frontend/src/API.js`) were changed and the changes match the intended behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a036e485580832396ca219be7877ee1)