### PR TITLE
Excel2SBOL: friendly error JSON + frontend "More" toggle

### DIFF
--- a/backend/sbs_server/app/views.py
+++ b/backend/sbs_server/app/views.py
@@ -5,6 +5,8 @@ from werkzeug.utils import secure_filename
 from .main import app
 from .utils import abstract_design_2_plasmids, sbol2build_moclo #, generate_transformation_metadata
 from .version import __version__
+import contextlib
+import io
 import sys
 import os
 import json
@@ -13,6 +15,86 @@ import tricahue
 import sbol2 as sb2
 import pudu
 import subprocess
+import traceback
+
+
+def classify_excel2sbol_error(exc):
+    if isinstance(exc, FileNotFoundError):
+        return {
+            "code": "E_INPUT_FILE",
+            "message": "The uploaded Excel file could not be read.",
+            "hint": "Check that the file was uploaded correctly.",
+            "status": 400,
+        }
+
+    if isinstance(exc, (KeyError, AttributeError)):
+        return {
+            "code": "E_WORKBOOK_STRUCTURE",
+            "message": "The Excel file is missing a required sheet, column, or SBOL mapping.",
+            "hint": "Check the Init sheet and column_definitions sheet.",
+            "status": 400,
+        }
+
+    if isinstance(exc, ValueError):
+        return {
+            "code": "E_WORKBOOK_VALUE",
+            "message": "A value in the Excel file could not be converted to SBOL.",
+            "hint": "Check the reported sheet, column, row, or pattern requirement.",
+            "status": 400,
+        }
+
+    return {
+        "code": "E_CONVERSION_FAILED",
+        "message": "Excel2SBOL failed during conversion.",
+        "hint": "Open More details and send the technical report to the developers.",
+        "status": 500,
+    }
+
+
+def redact_sensitive_values(text):
+    if text is None:
+        return ""
+
+    sensitive_values = [
+        os.getenv("SBOL_USERNAME"),
+        os.getenv("SBOL_PASSWORD"),
+        os.getenv("SBOL_URL"),
+        os.getenv("SYNBIOHUB_USERNAME"),
+        os.getenv("SYNBIOHUB_PASSWORD"),
+        os.getenv("SYNBIOHUB_URL"),
+    ]
+
+    for value in sensitive_values:
+        if value:
+            text = text.replace(value, "[REDACTED]")
+
+    return text
+
+
+def excel2sbol_error_response(exc, stdout_buffer, stderr_buffer):
+    terminal_output = "\n".join([
+        "STDOUT:",
+        stdout_buffer.getvalue(),
+        "",
+        "STDERR:",
+        stderr_buffer.getvalue(),
+    ])
+
+    classified = classify_excel2sbol_error(exc)
+
+    return jsonify({
+        "status": "error",
+        "error": {
+            "code": classified["code"],
+            "message": classified["message"],
+            "hint": classified["hint"],
+            "details": redact_sensitive_values(str(exc)),
+            "technical_details": {
+                "terminal_output": redact_sensitive_values(terminal_output),
+                "traceback": redact_sensitive_values(traceback.format_exc()),
+            },
+        },
+    }), classified["status"]
 
 #routes
 #check if the app is running
@@ -129,26 +211,32 @@ def sbh_fj_upload(files):
             os.remove(data_filename)
 
     # instantiate the XDC class using the params_from_request dictionary
+    stdout_buffer = io.StringIO()
+    stderr_buffer = io.StringIO()
+
     try:
-        xdc = tricahue.XDC(input_excel_path = metadata_path, attachments=attachments)
-        # print(params_from_request['sbh_url'], params_from_request['collection_url'], params_from_request['sbh_overwrite'], params_from_request['sbh_user'],params_from_request['sbh_pass'], params_from_request['sbh_pass'],params_from_request['fj_url'], params_from_request['fj_overwrite'], params_from_request['fj_user'], params_from_request['fj_pass'],params_from_request['fj_token'])
-        sbh_url, fj_url = xdc.upload_to_existing_collection(sbh_url = params_from_request['sbh_url'],
-                                      collection_url = params_from_request['collection_url'], 
-                                      sbh_overwrite = params_from_request['sbh_overwrite'], 
-                                      sbh_user = params_from_request['sbh_user'],
-                                      sbh_pass = params_from_request['sbh_pass'], 
-                                      sbh_token = params_from_request['sbh_token'],
-                                      fj_url = fj_url,
-                                      fj_overwrite = fj_overwrite, 
-                                      fj_user = fj_user, 
-                                      fj_pass = fj_pass,
-                                      fj_token = fj_token)
-    except AttributeError as e:
-        os.remove(metadata_path)
-        return jsonify({"error": str(e)}), 400
+        with contextlib.redirect_stdout(stdout_buffer), contextlib.redirect_stderr(stderr_buffer):
+            xdc = tricahue.XDC(input_excel_path = metadata_path, attachments=attachments)
+            # print(params_from_request['sbh_url'], params_from_request['collection_url'], params_from_request['sbh_overwrite'], params_from_request['sbh_user'],params_from_request['sbh_pass'], params_from_request['sbh_pass'],params_from_request['fj_url'], params_from_request['fj_overwrite'], params_from_request['fj_user'], params_from_request['fj_pass'],params_from_request['fj_token'])
+            sbh_url, fj_url = xdc.upload_to_existing_collection(sbh_url = params_from_request['sbh_url'],
+                                          collection_url = params_from_request['collection_url'], 
+                                          sbh_overwrite = params_from_request['sbh_overwrite'], 
+                                          sbh_user = params_from_request['sbh_user'],
+                                          sbh_pass = params_from_request['sbh_pass'], 
+                                          sbh_token = params_from_request['sbh_token'],
+                                          fj_url = fj_url,
+                                          fj_overwrite = fj_overwrite, 
+                                          fj_user = fj_user, 
+                                          fj_pass = fj_pass,
+                                          fj_token = fj_token)
     except Exception as e:
-        os.remove(metadata_path)
-        return jsonify({"error": str(e)}), 500
+        if os.path.exists(metadata_path):
+            os.remove(metadata_path)
+        app.logger.exception("Excel2SBOL conversion failed")
+        return excel2sbol_error_response(e, stdout_buffer, stderr_buffer)
+
+    sys.stdout.write(stdout_buffer.getvalue())
+    sys.stderr.write(stderr_buffer.getvalue())
 
     sbs_upload_response_dict ={
         "sbh_url": sbh_url,
@@ -328,4 +416,3 @@ def inspect_request():
     return jsonify({
         "message": "Request received successfully", 
         "files": files}), 200
-

--- a/backend/tests/test_excel2sbol_errors.py
+++ b/backend/tests/test_excel2sbol_errors.py
@@ -1,0 +1,72 @@
+import io
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("flask")
+pytest.importorskip("flask_cors")
+pytest.importorskip("flask_swagger_ui")
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+for module_name in ("tricahue", "sbol2", "pudu"):
+    sys.modules.setdefault(module_name, types.SimpleNamespace())
+
+sbol2build = types.SimpleNamespace(
+    abstract_translator=types.SimpleNamespace(),
+    golden_gate_assembly_plan=lambda *args, **kwargs: None,
+)
+sys.modules.setdefault("sbol2build", sbol2build)
+sys.modules.setdefault("sbol2build.abstract_translator", sbol2build.abstract_translator)
+
+from sbs_server.app.main import app
+from sbs_server.app import views
+
+
+def test_upload_resource_returns_friendly_excel2sbol_value_error(monkeypatch):
+    monkeypatch.setenv("SYNBIOHUB_PASSWORD", "super-secret-password")
+
+    class FailingXDC:
+        def __init__(self, input_excel_path, attachments=None):
+            print("starting Excel2SBOL conversion with super-secret-password")
+            raise ValueError("bad pattern for super-secret-password")
+
+    monkeypatch.setattr(views.tricahue, "XDC", FailingXDC)
+
+    client = app.test_client()
+    params = {
+        "sbh_url": "https://synbiohub.example",
+        "sbh_token": "token",
+        "sbh_user": None,
+        "sbh_pass": None,
+        "collection_url": "https://synbiohub.example/public/test_collection/test_collection_collection/1",
+        "sbh_overwrite": 0,
+    }
+
+    response = client.post(
+        "/api/uploadResource",
+        data={
+            "Metadata": (io.BytesIO(b"fake workbook"), "metadata.xlsx"),
+            "Params": (io.BytesIO(json.dumps(params).encode("utf-8")), "params.json"),
+        },
+        content_type="multipart/form-data",
+    )
+
+    assert response.status_code == 400
+    payload = response.get_json()
+    assert payload["status"] == "error"
+    assert payload["error"]["code"] == "E_WORKBOOK_VALUE"
+    assert payload["error"]["message"] == "A value in the Excel file could not be converted to SBOL."
+    assert payload["error"]["hint"] == "Check the reported sheet, column, row, or pattern requirement."
+    assert "bad pattern" in payload["error"]["details"]
+    assert "technical_details" in payload["error"]
+    assert "STDOUT:" in payload["error"]["technical_details"]["terminal_output"]
+    assert "starting Excel2SBOL conversion" in payload["error"]["technical_details"]["terminal_output"]
+    assert "Traceback" in payload["error"]["technical_details"]["traceback"]
+    assert "ValueError" in payload["error"]["technical_details"]["traceback"]
+    assert "super-secret-password" not in json.dumps(payload)
+    assert "[REDACTED]" in json.dumps(payload)
+    assert "details_url" not in payload["error"]

--- a/frontend/src/components/activities/explorer/ImportFile.jsx
+++ b/frontend/src/components/activities/explorer/ImportFile.jsx
@@ -205,6 +205,9 @@ export default function ImportFile({ onSelect, text, useSubdirectory = false }) 
 
             onSelect?.(fileMetadata)
         } catch (err) {
+            if (err?.response?.data?.error) {
+                showErrorNotification("Upload failed", err.response.data.error)
+            }
             console.warn("File selection canceled or failed", err)
         }
     }

--- a/frontend/src/modules/util.js
+++ b/frontend/src/modules/util.js
@@ -1,3 +1,4 @@
+import React, { useState } from "react"
 import { showNotification } from "@mantine/notifications"
 
 export function titleFromRunFileName(fileName) {
@@ -20,7 +21,65 @@ export function showErrorNotification(title, message) {
     showNotification({
         title,
         color: "red",
-        message,
+        message: typeof message === "object" && message !== null
+            ? React.createElement(ConversionError, { error: message })
+            : message,
         autoClose: false,
     });
+}
+
+function ConversionError({ error }) {
+    const [showDetails, setShowDetails] = useState(false)
+
+    if (!error) {
+        return null
+    }
+
+    const technicalDetails = [
+        `Error code: ${error.code || ""}`,
+        "",
+        "Details:",
+        error.details || "",
+        "",
+        "Terminal output:",
+        error.technical_details?.terminal_output || "",
+        "",
+        "Python traceback:",
+        error.technical_details?.traceback || "",
+    ].join("\n")
+
+    return React.createElement(
+        "div",
+        null,
+        React.createElement("strong", null, error.message || "Conversion failed"),
+        error.hint ? React.createElement("p", null, error.hint) : null,
+        React.createElement(
+            "button",
+            {
+                type: "button",
+                onClick: () => setShowDetails(!showDetails),
+                style: {
+                    background: "transparent",
+                    border: "1px solid currentColor",
+                    borderRadius: 4,
+                    color: "inherit",
+                    cursor: "pointer",
+                    padding: "2px 8px",
+                },
+            },
+            showDetails ? "Hide details" : "More"
+        ),
+        showDetails ? React.createElement(
+            "pre",
+            {
+                style: {
+                    marginTop: 8,
+                    maxHeight: 300,
+                    overflow: "auto",
+                    whiteSpace: "pre-wrap",
+                },
+            },
+            technicalDetails
+        ) : null
+    )
 }


### PR DESCRIPTION
### Motivation
- Make Excel2SBOL conversion failures user-friendly by returning a single JSON error payload with a short message and hint while preserving full terminal output and traceback for developers. 
- Avoid extra endpoints or additional API calls: the technical data must be returned in the same response and only revealed in the UI after user interaction.

### Description
- Capture Excel2SBOL/XDC stdout and stderr during conversion using `contextlib.redirect_stdout`/`redirect_stderr` and return a structured error JSON containing `status: "error"`, `error.code`, `error.message`, `error.hint`, `error.details`, and `error.technical_details` with `terminal_output` and `traceback` (backend `backend/sbs_server/app/views.py`).
- Classify common exceptions (`FileNotFoundError`, `KeyError`/`AttributeError`, `ValueError`, other) into friendly `code`/`message`/`hint`/`status` values and redact likely sensitive environment values before including technical details in the response (backend helper functions in `views.py`).
- Keep successful conversion behavior unchanged and replay captured stdout/stderr to the server stdout/stderr on success for backward-compatible logging (backend `views.py`).
- Render structured errors in a notification component that shows only the friendly `message` and `hint` by default and includes a local `More` / `Hide details` toggle that reveals the included `technical_details` without any extra fetch (frontend `frontend/src/modules/util.js`).
- Surface structured upload errors from the collection/workflow import flow so the same notification UI is used (frontend `frontend/src/components/activities/explorer/ImportFile.jsx`).

### Testing
- Added a backend pytest `backend/tests/test_excel2sbol_errors.py` that simulates XDC raising `ValueError` and asserts the friendly response shape, presence of `technical_details`, and redaction of sensitive env values; test was instrumented to skip if Flask and related packages are not available in the environment.
- Ran `python -m py_compile` on the modified backend files successfully and executed `python -m pytest backend/tests/test_excel2sbol_errors.py` which completed but reported the test as skipped in this environment due to missing Flask server dependencies.
- Built the frontend with `cd frontend && npm run build` which completed successfully (Vite warnings about bundle size/duplicate style keys are pre-existing and non-blocking).
- Changed files: `backend/sbs_server/app/views.py`, `frontend/src/modules/util.js`, `frontend/src/components/activities/explorer/ImportFile.jsx`, and added `backend/tests/test_excel2sbol_errors.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a233f257a148323a6e5a5b7c25c05aa)