### PR TITLE
Split PR validation from production deploy for Azure Static Web Apps to avoid staging exhaustion

### DIFF
--- a/.github/workflows/azure-static-web-apps-witty-hill-08172a210.yml
+++ b/.github/workflows/azure-static-web-apps-witty-hill-08172a210.yml
@@ -21,17 +21,44 @@ on:
     branches:
       - master
 
+concurrency:
+  group: azure-static-web-apps-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  build_and_deploy_job:
+  validate_pull_request_job:
     if: >
-      github.event_name == 'push' ||
-      (github.event_name == 'pull_request' &&
-       github.event.action != 'closed' &&
-       github.event.pull_request.draft == false)
+      github.event_name == 'pull_request' &&
+      github.event.action != 'closed' &&
+      github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    name: Validate Pull Request
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+          lfs: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package.json
+      - name: Install dependencies
+        working-directory: frontend
+        run: npm install
+      - name: Run tests
+        working-directory: frontend
+        run: npm test
+      - name: Build app
+        working-directory: frontend
+        run: npm run build
+
+  build_and_deploy_job:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
           lfs: false
@@ -40,7 +67,6 @@ jobs:
         uses: Azure/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_WITTY_HILL_08172A210 }}
-          repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)
           action: "upload"
           ###### Repository/Build Configurations - These values can be configured to match your app requirements. ######
           # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
@@ -63,4 +89,3 @@ jobs:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_WITTY_HILL_08172A210 }}
           action: "close"
           app_location: "/"
-

--- a/.github/workflows/azure-static-web-apps-witty-hill-08172a210.yml
+++ b/.github/workflows/azure-static-web-apps-witty-hill-08172a210.yml
@@ -22,8 +22,9 @@ on:
       - master
 
 concurrency:
-  group: azure-static-web-apps-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: >
+    azure-static-web-apps-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}-${{ (github.event_name == 'pull_request' && (github.event.action == 'closed' || github.event.action == 'converted_to_draft')) && 'cleanup' || 'active' }}
+  cancel-in-progress: ${{ !(github.event_name == 'pull_request' && (github.event.action == 'closed' || github.event.action == 'converted_to_draft')) }}
 
 jobs:
   validate_pull_request_job:


### PR DESCRIPTION
### Motivation
- Pull-request runs were creating Azure Static Web Apps staging environments and hit the account limit, causing a `BadRequest` and failed CI despite the frontend build being successful locally.
- The goal is to validate PRs (install, test, build) without uploading or creating staging environments, while keeping production deploys on `push` to `master`.

### Description
- Added a `validate_pull_request_job` in `.github/workflows/azure-static-web-apps-witty-hill-08172a210.yml` that runs on PRs and performs `actions/checkout@v4`, `actions/setup-node@v4` (Node 20), `npm install`, `npm test`, and `npm run build` without calling the Azure Static Web Apps deploy action.
- Restricted the Azure SWA `build_and_deploy_job` to only run on `push` events so staging slots are not consumed by PRs.
- Introduced workflow-level `concurrency` to cancel superseded runs for the same PR/ref and reduce redundant work.
- Kept the `close_pull_request_job` that calls the Azure SWA action with `action: "close"` so preview environments can still be cleaned up when a PR is closed or converted to draft.

### Testing
- Ran `npm install` in `frontend` and it completed successfully.
- Ran `npm test` and the test suite passed (3 tests passed, 0 failed).
- Ran `npm run build` and the Vite production build completed (build warnings about chunk size were reported but the `dist` output was produced).
- Executed `git diff --check` with no actionable workflow lint errors, and attempted YAML parse but `PyYAML` was not available in the environment so YAML validation was skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a584c3c4020832387d5620b4b40e95e)