### PR TITLE
Deploy staged previews after validation

### DIFF
--- a/.github/workflows/azure-static-web-apps-witty-hill-08172a210.yml
+++ b/.github/workflows/azure-static-web-apps-witty-hill-08172a210.yml
@@ -66,6 +66,7 @@ jobs:
        (github.event_name == 'pull_request' &&
         github.event.action != 'closed' &&
         github.event.pull_request.draft == false &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
         needs.validate_pull_request_job.result == 'success'))
     runs-on: ubuntu-latest
     name: Build and Deploy Job

--- a/.github/workflows/azure-static-web-apps-witty-hill-08172a210.yml
+++ b/.github/workflows/azure-static-web-apps-witty-hill-08172a210.yml
@@ -2,6 +2,7 @@ name: Azure Static Web Apps CI/CD
 
 permissions:
   contents: read
+  pull-requests: write
 
 env:
   VITE_IBIOSIM_API: https://ibiosimconnector-api.azurewebsites.net/api/orchestrators/analyze
@@ -58,7 +59,14 @@ jobs:
         run: npm run build
 
   build_and_deploy_job:
-    if: github.event_name == 'push'
+    needs: validate_pull_request_job
+    if: >
+      always() &&
+      (github.event_name == 'push' ||
+       (github.event_name == 'pull_request' &&
+        github.event.action != 'closed' &&
+        github.event.pull_request.draft == false &&
+        needs.validate_pull_request_job.result == 'success'))
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:
@@ -71,6 +79,7 @@ jobs:
         uses: Azure/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_WITTY_HILL_08172A210 }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for GitHub integrations (i.e. PR comments)
           action: "upload"
           ###### Repository/Build Configurations - These values can be configured to match your app requirements. ######
           # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig


### PR DESCRIPTION
## What changed

- Run the Azure Static Web Apps staged deployment for an active pull request only after `Validate Pull Request` succeeds.
- Preserve the existing production deployment on pushes to `master`.
- Grant `pull-requests: write` and pass `GITHUB_TOKEN` so Azure Static Web Apps can publish the preview URL on the pull request.

## Why

PR #413 currently runs validation successfully but skips `Build and Deploy Job`, so no staged preview is created.

## Validation

- Reviewed the workflow job conditions and dependency graph.
- The staged deploy is gated by `needs.validate_pull_request_job.result == 'success'`.
